### PR TITLE
Convert PulseEffects presets to EasyEffects presets

### DIFF
--- a/Aura 15/Aura 15.json
+++ b/Aura 15/Aura 15.json
@@ -1,1 +1,1 @@
-InfinityBook S15 Gen6.json
+../InfinityBook S15 Gen6/InfinityBook S15 Gen6.json

--- a/BA15/BA15.json
+++ b/BA15/BA15.json
@@ -1,1 +1,1 @@
-Pulse 15.json
+../Pulse 15/Pulse 15.json

--- a/InfinityBook Pro 13/InfinityBook Pro 13.json
+++ b/InfinityBook Pro 13/InfinityBook Pro 13.json
@@ -1,413 +1,396 @@
 {
     "spectrum": {
-        "show": "true",
-        "n-points": "100",
-        "height": "100",
-        "use-custom-color": "false",
-        "fill": "true",
-        "show-bar-border": "true",
-        "scale": "1",
-        "exponent": "1",
-        "sampling-freq": "10",
-        "line-width": "2",
+        "show": true,
+        "n-points": 100,
+        "height": 100,
+        "use-custom-color": false,
+        "fill": true,
+        "show-bar-border": true,
+        "scale": 1,
+        "exponent": 1,
+        "sampling-freq": 10,
+        "line-width": 2,
         "type": "Bars",
         "color": [
-            "1",
-            "1",
-            "1",
-            "1"
+            1,
+            1,
+            1,
+            1
         ],
         "gradient-color": [
-            "0",
-            "0",
-            "0",
-            "1"
+            0,
+            0,
+            0,
+            1
         ]
     },
     "output": {
         "blacklist": "",
         "plugins_order": [
-            "limiter",
-            "autogain",
-            "gate",
-            "multiband_gate",
-            "compressor",
-            "multiband_compressor",
-            "bass_enhancer",
-            "convolver",
             "exciter",
-            "crystalizer",
             "stereo_tools",
-            "reverb",
-            "equalizer",
-            "delay",
-            "deesser",
-            "crossfeed",
-            "loudness",
-            "maximizer",
-            "filter",
-            "pitch"
+            "filter"
         ],
         "bass_enhancer": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "1",
-            "harmonics": "9.9999999999999947",
-            "scope": "250",
-            "floor": "58",
-            "blend": "1",
-            "floor-active": "false",
-            "listen": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 1,
+            "harmonics": 9.999999999999995,
+            "scope": 250,
+            "floor": 58,
+            "blend": 1,
+            "floor-active": false,
+            "listen": false
         },
         "compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "mode": "Downward",
-            "attack": "20",
-            "release": "100",
-            "threshold": "-12",
-            "ratio": "4",
-            "knee": "-6",
-            "makeup": "0",
+            "attack": 20,
+            "release": 100,
+            "threshold": -12,
+            "ratio": 4,
+            "knee": -6,
+            "makeup": 0,
             "sidechain": {
-                "listen": "false",
+                "listen": false,
                 "type": "Feed-forward",
                 "mode": "RMS",
                 "source": "Middle",
-                "preamp": "0",
-                "reactivity": "10",
-                "lookahead": "0"
+                "preamp": 0,
+                "reactivity": 10,
+                "lookahead": 0
             }
         },
         "crossfeed": {
-            "state": "false",
-            "fcut": "700",
-            "feed": "4.5"
+            "state": false,
+            "fcut": 700,
+            "feed": 4.5
         },
         "deesser": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "mode": "Wide",
-            "threshold": "-18",
-            "ratio": "3",
-            "laxity": "15",
-            "makeup": "0",
-            "f1-freq": "6000",
-            "f2-freq": "4500",
-            "f1-level": "0",
-            "f2-level": "12",
-            "f2-q": "1",
-            "sc-listen": "false"
+            "threshold": -18,
+            "ratio": 3,
+            "laxity": 15,
+            "makeup": 0,
+            "f1-freq": 6000,
+            "f2-freq": 4500,
+            "f1-level": 0,
+            "f2-level": 12,
+            "f2-q": 1,
+            "sc-listen": false
         },
         "equalizer": {
-            "state": "false",
+            "state": false,
             "mode": "IIR",
-            "num-bands": "30",
-            "input-gain": "0",
-            "output-gain": "0",
-            "split-channels": "false",
+            "num-bands": 30,
+            "input-gain": 0,
+            "output-gain": 0,
+            "split-channels": false,
             "left": {
                 "band0": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             },
             "right": {
@@ -415,610 +398,611 @@
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             }
         },
         "exciter": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "4",
-            "harmonics": "9.9999999999999947",
-            "scope": "7846",
-            "ceil": "16076",
-            "blend": "-5",
-            "ceil-active": "false",
-            "listen": "false"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 4,
+            "harmonics": 9.999999999999995,
+            "scope": 7846,
+            "ceil": 16076,
+            "blend": -5,
+            "ceil-active": false,
+            "listen": false
         },
         "filter": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "frequency": "305.81799999999998",
-            "resonance": "0.70699999999999996",
-            "mode": "12dB\/oct Highpass",
-            "inertia": "74"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "frequency": 305.818,
+            "resonance": 0.707,
+            "mode": "12dB/oct Highpass",
+            "inertia": 74
         },
         "gate": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "stereo-link": "Average",
-            "range": "-24",
-            "attack": "20",
-            "release": "250",
-            "threshold": "-18",
-            "ratio": "2",
-            "knee": "9",
-            "makeup": "0"
+            "range": -24,
+            "attack": 20,
+            "release": 250,
+            "threshold": -18,
+            "ratio": 2,
+            "knee": 9,
+            "makeup": 0
         },
         "limiter": {
-            "state": "false",
-            "input-gain": "5",
-            "limit": "0",
-            "lookahead": "5",
-            "release": "50",
-            "asc": "false",
-            "asc-level": "0.5",
-            "oversampling": "1"
+            "state": false,
+            "input-gain": 5,
+            "limit": 0,
+            "lookahead": 5,
+            "release": 50,
+            "asc": false,
+            "asc-level": 0.5,
+            "oversampling": 1
         },
         "maximizer": {
-            "state": "false",
-            "release": "24.979999999999997",
-            "ceiling": "-2",
-            "threshold": "-2"
+            "state": false,
+            "release": 24.979999999999997,
+            "ceiling": -2,
+            "threshold": -2
         },
         "pitch": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "cents": "0",
-            "semitones": "0",
-            "octaves": "0",
-            "crispness": "3",
-            "formant-preserving": "false",
-            "faster": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "cents": 0,
+            "semitones": 0,
+            "octaves": 0,
+            "crispness": 3,
+            "formant-preserving": false,
+            "faster": false
         },
         "reverb": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "room-size": "Large",
-            "decay-time": "1.5",
-            "hf-damp": "5000",
-            "diffusion": "0.5",
-            "amount": "-12",
-            "dry": "0",
-            "predelay": "0",
-            "bass-cut": "300",
-            "treble-cut": "5000"
+            "decay-time": 1.5,
+            "hf-damp": 5000,
+            "diffusion": 0.5,
+            "amount": -12,
+            "dry": 0,
+            "predelay": 0,
+            "bass-cut": 300,
+            "treble-cut": 5000
         },
         "multiband_compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "loudness": {
-            "state": "false",
-            "loudness": "-3.1000000000000001",
-            "output": "-6",
-            "link": "-9.0999999999999996"
+            "state": false,
+            "loudness": -3.1,
+            "output": -6,
+            "link": -9.1
         },
         "multiband_gate": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "stereo_tools": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "balance-in": "0",
-            "balance-out": "0",
-            "softclip": "false",
-            "mutel": "false",
-            "muter": "false",
-            "phasel": "false",
-            "phaser": "false",
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "balance-in": 0,
+            "balance-out": 0,
+            "softclip": false,
+            "mutel": false,
+            "muter": false,
+            "phasel": false,
+            "phaser": false,
             "mode": "LR > LR (Stereo Default)",
-            "side-level": "-1",
-            "side-balance": "0.099999999999999992",
-            "middle-level": "3",
-            "middle-panorama": "-0.099999999999999242",
-            "stereo-base": "0",
-            "delay": "0",
-            "sc-level": "1",
-            "stereo-phase": "0"
+            "side-level": -1,
+            "side-balance": 0.09999999999999999,
+            "middle-level": 3,
+            "middle-panorama": -0.09999999999999924,
+            "stereo-base": 0,
+            "delay": 0,
+            "sc-level": 1,
+            "stereo-phase": 0
         },
         "convolver": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "kernel-path": "",
-            "ir-width": "87"
+            "ir-width": 87
         },
         "crystalizer": {
-            "state": "false",
-            "aggressive": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "aggressive": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "band0": {
-                "intensity": "12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 12,
+                "mute": false,
+                "bypass": false
             },
             "band1": {
-                "intensity": "3",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 3,
+                "mute": false,
+                "bypass": false
             },
             "band2": {
-                "intensity": "-13",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -13,
+                "mute": false,
+                "bypass": false
             },
             "band3": {
-                "intensity": "0",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 0,
+                "mute": false,
+                "bypass": false
             },
             "band4": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band5": {
-                "intensity": "-8",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -8,
+                "mute": false,
+                "bypass": false
             },
             "band6": {
-                "intensity": "7",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 7,
+                "mute": false,
+                "bypass": false
             },
             "band7": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band8": {
-                "intensity": "-9",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -9,
+                "mute": false,
+                "bypass": false
             },
             "band9": {
-                "intensity": "-19",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -19,
+                "mute": false,
+                "bypass": false
             },
             "band10": {
-                "intensity": "-21",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -21,
+                "mute": false,
+                "bypass": false
             },
             "band11": {
-                "intensity": "-10",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -10,
+                "mute": false,
+                "bypass": false
             },
             "band12": {
-                "intensity": "-12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -12,
+                "mute": false,
+                "bypass": false
             }
         },
         "autogain": {
-            "state": "false",
-            "detect-silence": "false",
-            "use-geometric-mean": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "target": "-23",
-            "weight-m": "1",
-            "weight-s": "1",
-            "weight-i": "1"
+            "state": false,
+            "detect-silence": false,
+            "use-geometric-mean": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "target": -23,
+            "weight-m": 1,
+            "weight-s": 1,
+            "weight-i": 1
         },
         "delay": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "time-l": "0",
-            "time-r": "0"
-        }
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "time-l": 0,
+            "time-r": 0
+        },
+        "blocklist": []
     }
 }

--- a/InfinityBook S15 Gen6/InfinityBook S15 Gen6.json
+++ b/InfinityBook S15 Gen6/InfinityBook S15 Gen6.json
@@ -1,413 +1,396 @@
 {
     "spectrum": {
-        "show": "true",
-        "n-points": "100",
-        "height": "100",
-        "use-custom-color": "false",
-        "fill": "true",
-        "show-bar-border": "true",
-        "scale": "1",
-        "exponent": "1",
-        "sampling-freq": "10",
-        "line-width": "2",
+        "show": true,
+        "n-points": 100,
+        "height": 100,
+        "use-custom-color": false,
+        "fill": true,
+        "show-bar-border": true,
+        "scale": 1,
+        "exponent": 1,
+        "sampling-freq": 10,
+        "line-width": 2,
         "type": "Bars",
         "color": [
-            "1",
-            "1",
-            "1",
-            "1"
+            1,
+            1,
+            1,
+            1
         ],
         "gradient-color": [
-            "0",
-            "0",
-            "0",
-            "1"
+            0,
+            0,
+            0,
+            1
         ]
     },
     "output": {
         "blacklist": "",
         "plugins_order": [
-            "limiter",
-            "autogain",
-            "gate",
-            "multiband_gate",
-            "compressor",
-            "multiband_compressor",
-            "bass_enhancer",
-            "convolver",
             "exciter",
-            "crystalizer",
             "stereo_tools",
-            "reverb",
-            "equalizer",
-            "delay",
-            "deesser",
-            "crossfeed",
-            "loudness",
-            "maximizer",
-            "filter",
-            "pitch"
+            "filter"
         ],
         "bass_enhancer": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "1",
-            "harmonics": "9.9999999999999947",
-            "scope": "250",
-            "floor": "58",
-            "blend": "1",
-            "floor-active": "false",
-            "listen": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 1,
+            "harmonics": 9.999999999999995,
+            "scope": 250,
+            "floor": 58,
+            "blend": 1,
+            "floor-active": false,
+            "listen": false
         },
         "compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "mode": "Downward",
-            "attack": "20",
-            "release": "100",
-            "threshold": "-12",
-            "ratio": "4",
-            "knee": "-6",
-            "makeup": "0",
+            "attack": 20,
+            "release": 100,
+            "threshold": -12,
+            "ratio": 4,
+            "knee": -6,
+            "makeup": 0,
             "sidechain": {
-                "listen": "false",
+                "listen": false,
                 "type": "Feed-forward",
                 "mode": "RMS",
                 "source": "Middle",
-                "preamp": "0",
-                "reactivity": "10",
-                "lookahead": "0"
+                "preamp": 0,
+                "reactivity": 10,
+                "lookahead": 0
             }
         },
         "crossfeed": {
-            "state": "false",
-            "fcut": "700",
-            "feed": "4.5"
+            "state": false,
+            "fcut": 700,
+            "feed": 4.5
         },
         "deesser": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "mode": "Wide",
-            "threshold": "-18",
-            "ratio": "3",
-            "laxity": "15",
-            "makeup": "0",
-            "f1-freq": "6000",
-            "f2-freq": "4500",
-            "f1-level": "0",
-            "f2-level": "12",
-            "f2-q": "1",
-            "sc-listen": "false"
+            "threshold": -18,
+            "ratio": 3,
+            "laxity": 15,
+            "makeup": 0,
+            "f1-freq": 6000,
+            "f2-freq": 4500,
+            "f1-level": 0,
+            "f2-level": 12,
+            "f2-q": 1,
+            "sc-listen": false
         },
         "equalizer": {
-            "state": "false",
+            "state": false,
             "mode": "IIR",
-            "num-bands": "30",
-            "input-gain": "0",
-            "output-gain": "0",
-            "split-channels": "false",
+            "num-bands": 30,
+            "input-gain": 0,
+            "output-gain": 0,
+            "split-channels": false,
             "left": {
                 "band0": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             },
             "right": {
@@ -415,610 +398,611 @@
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             }
         },
         "exciter": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "4",
-            "harmonics": "9.9999999999999947",
-            "scope": "7846",
-            "ceil": "16076",
-            "blend": "-5",
-            "ceil-active": "false",
-            "listen": "false"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 4,
+            "harmonics": 9.999999999999995,
+            "scope": 7846,
+            "ceil": 16076,
+            "blend": -5,
+            "ceil-active": false,
+            "listen": false
         },
         "filter": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "frequency": "305.81799999999998",
-            "resonance": "0.70699999999999996",
-            "mode": "12dB\/oct Highpass",
-            "inertia": "74"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "frequency": 305.818,
+            "resonance": 0.707,
+            "mode": "12dB/oct Highpass",
+            "inertia": 74
         },
         "gate": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "stereo-link": "Average",
-            "range": "-24",
-            "attack": "20",
-            "release": "250",
-            "threshold": "-18",
-            "ratio": "2",
-            "knee": "9",
-            "makeup": "0"
+            "range": -24,
+            "attack": 20,
+            "release": 250,
+            "threshold": -18,
+            "ratio": 2,
+            "knee": 9,
+            "makeup": 0
         },
         "limiter": {
-            "state": "false",
-            "input-gain": "5",
-            "limit": "0",
-            "lookahead": "5",
-            "release": "50",
-            "asc": "false",
-            "asc-level": "0.5",
-            "oversampling": "1"
+            "state": false,
+            "input-gain": 5,
+            "limit": 0,
+            "lookahead": 5,
+            "release": 50,
+            "asc": false,
+            "asc-level": 0.5,
+            "oversampling": 1
         },
         "maximizer": {
-            "state": "false",
-            "release": "24.979999999999997",
-            "ceiling": "-2",
-            "threshold": "-2"
+            "state": false,
+            "release": 24.979999999999997,
+            "ceiling": -2,
+            "threshold": -2
         },
         "pitch": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "cents": "0",
-            "semitones": "0",
-            "octaves": "0",
-            "crispness": "3",
-            "formant-preserving": "false",
-            "faster": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "cents": 0,
+            "semitones": 0,
+            "octaves": 0,
+            "crispness": 3,
+            "formant-preserving": false,
+            "faster": false
         },
         "reverb": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "room-size": "Large",
-            "decay-time": "1.5",
-            "hf-damp": "5000",
-            "diffusion": "0.5",
-            "amount": "-12",
-            "dry": "0",
-            "predelay": "0",
-            "bass-cut": "300",
-            "treble-cut": "5000"
+            "decay-time": 1.5,
+            "hf-damp": 5000,
+            "diffusion": 0.5,
+            "amount": -12,
+            "dry": 0,
+            "predelay": 0,
+            "bass-cut": 300,
+            "treble-cut": 5000
         },
         "multiband_compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "loudness": {
-            "state": "false",
-            "loudness": "-3.1000000000000001",
-            "output": "-6",
-            "link": "-9.0999999999999996"
+            "state": false,
+            "loudness": -3.1,
+            "output": -6,
+            "link": -9.1
         },
         "multiband_gate": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "stereo_tools": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "balance-in": "0",
-            "balance-out": "0",
-            "softclip": "false",
-            "mutel": "false",
-            "muter": "false",
-            "phasel": "false",
-            "phaser": "false",
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "balance-in": 0,
+            "balance-out": 0,
+            "softclip": false,
+            "mutel": false,
+            "muter": false,
+            "phasel": false,
+            "phaser": false,
             "mode": "LR > LR (Stereo Default)",
-            "side-level": "-1",
-            "side-balance": "0.099999999999999992",
-            "middle-level": "3",
-            "middle-panorama": "-0.099999999999999242",
-            "stereo-base": "0",
-            "delay": "0",
-            "sc-level": "1",
-            "stereo-phase": "0"
+            "side-level": -1,
+            "side-balance": 0.09999999999999999,
+            "middle-level": 3,
+            "middle-panorama": -0.09999999999999924,
+            "stereo-base": 0,
+            "delay": 0,
+            "sc-level": 1,
+            "stereo-phase": 0
         },
         "convolver": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "kernel-path": "",
-            "ir-width": "87"
+            "ir-width": 87
         },
         "crystalizer": {
-            "state": "false",
-            "aggressive": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "aggressive": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "band0": {
-                "intensity": "12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 12,
+                "mute": false,
+                "bypass": false
             },
             "band1": {
-                "intensity": "3",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 3,
+                "mute": false,
+                "bypass": false
             },
             "band2": {
-                "intensity": "-13",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -13,
+                "mute": false,
+                "bypass": false
             },
             "band3": {
-                "intensity": "0",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 0,
+                "mute": false,
+                "bypass": false
             },
             "band4": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band5": {
-                "intensity": "-8",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -8,
+                "mute": false,
+                "bypass": false
             },
             "band6": {
-                "intensity": "7",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 7,
+                "mute": false,
+                "bypass": false
             },
             "band7": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band8": {
-                "intensity": "-9",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -9,
+                "mute": false,
+                "bypass": false
             },
             "band9": {
-                "intensity": "-19",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -19,
+                "mute": false,
+                "bypass": false
             },
             "band10": {
-                "intensity": "-21",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -21,
+                "mute": false,
+                "bypass": false
             },
             "band11": {
-                "intensity": "-10",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -10,
+                "mute": false,
+                "bypass": false
             },
             "band12": {
-                "intensity": "-12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -12,
+                "mute": false,
+                "bypass": false
             }
         },
         "autogain": {
-            "state": "false",
-            "detect-silence": "false",
-            "use-geometric-mean": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "target": "-23",
-            "weight-m": "1",
-            "weight-s": "1",
-            "weight-i": "1"
+            "state": false,
+            "detect-silence": false,
+            "use-geometric-mean": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "target": -23,
+            "weight-m": 1,
+            "weight-s": 1,
+            "weight-i": 1
         },
         "delay": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "time-l": "0",
-            "time-r": "0"
-        }
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "time-l": 0,
+            "time-r": 0
+        },
+        "blocklist": []
     }
 }

--- a/Normal.json
+++ b/Normal.json
@@ -1,413 +1,392 @@
 {
     "spectrum": {
-        "show": "true",
-        "n-points": "100",
-        "height": "100",
-        "use-custom-color": "false",
-        "fill": "true",
-        "show-bar-border": "true",
-        "scale": "1",
-        "exponent": "1",
-        "sampling-freq": "10",
-        "line-width": "2",
+        "show": true,
+        "n-points": 100,
+        "height": 100,
+        "use-custom-color": false,
+        "fill": true,
+        "show-bar-border": true,
+        "scale": 1,
+        "exponent": 1,
+        "sampling-freq": 10,
+        "line-width": 2,
         "type": "Bars",
         "color": [
-            "1",
-            "1",
-            "1",
-            "1"
+            1,
+            1,
+            1,
+            1
         ],
         "gradient-color": [
-            "0",
-            "0",
-            "0",
-            "1"
+            0,
+            0,
+            0,
+            1
         ]
     },
     "output": {
         "blacklist": "",
-        "plugins_order": [
-            "limiter",
-            "autogain",
-            "gate",
-            "multiband_gate",
-            "compressor",
-            "multiband_compressor",
-            "bass_enhancer",
-            "convolver",
-            "exciter",
-            "crystalizer",
-            "stereo_tools",
-            "reverb",
-            "equalizer",
-            "delay",
-            "deesser",
-            "crossfeed",
-            "loudness",
-            "maximizer",
-            "filter",
-            "pitch"
-        ],
+        "plugins_order": [],
         "bass_enhancer": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "1",
-            "harmonics": "9.9999999999999947",
-            "scope": "250",
-            "floor": "58",
-            "blend": "1",
-            "floor-active": "false",
-            "listen": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 1,
+            "harmonics": 9.999999999999995,
+            "scope": 250,
+            "floor": 58,
+            "blend": 1,
+            "floor-active": false,
+            "listen": false
         },
         "compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "mode": "Downward",
-            "attack": "20",
-            "release": "100",
-            "threshold": "-12",
-            "ratio": "4",
-            "knee": "-6",
-            "makeup": "0",
+            "attack": 20,
+            "release": 100,
+            "threshold": -12,
+            "ratio": 4,
+            "knee": -6,
+            "makeup": 0,
             "sidechain": {
-                "listen": "false",
+                "listen": false,
                 "type": "Feed-forward",
                 "mode": "RMS",
                 "source": "Middle",
-                "preamp": "0",
-                "reactivity": "10",
-                "lookahead": "0"
+                "preamp": 0,
+                "reactivity": 10,
+                "lookahead": 0
             }
         },
         "crossfeed": {
-            "state": "false",
-            "fcut": "700",
-            "feed": "4.5"
+            "state": false,
+            "fcut": 700,
+            "feed": 4.5
         },
         "deesser": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "mode": "Wide",
-            "threshold": "-18",
-            "ratio": "3",
-            "laxity": "15",
-            "makeup": "0",
-            "f1-freq": "6000",
-            "f2-freq": "4500",
-            "f1-level": "0",
-            "f2-level": "12",
-            "f2-q": "1",
-            "sc-listen": "false"
+            "threshold": -18,
+            "ratio": 3,
+            "laxity": 15,
+            "makeup": 0,
+            "f1-freq": 6000,
+            "f2-freq": 4500,
+            "f1-level": 0,
+            "f2-level": 12,
+            "f2-q": 1,
+            "sc-listen": false
         },
         "equalizer": {
-            "state": "false",
+            "state": false,
             "mode": "IIR",
-            "num-bands": "30",
-            "input-gain": "0",
-            "output-gain": "0",
-            "split-channels": "false",
+            "num-bands": 30,
+            "input-gain": 0,
+            "output-gain": 0,
+            "split-channels": false,
             "left": {
                 "band0": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             },
             "right": {
@@ -415,610 +394,611 @@
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             }
         },
         "exciter": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "4",
-            "harmonics": "9.9999999999999947",
-            "scope": "7846",
-            "ceil": "16076",
-            "blend": "-5",
-            "ceil-active": "false",
-            "listen": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 4,
+            "harmonics": 9.999999999999995,
+            "scope": 7846,
+            "ceil": 16076,
+            "blend": -5,
+            "ceil-active": false,
+            "listen": false
         },
         "filter": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "frequency": "305.81799999999998",
-            "resonance": "0.70699999999999996",
-            "mode": "12dB\/oct Highpass",
-            "inertia": "74"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "frequency": 305.818,
+            "resonance": 0.707,
+            "mode": "12dB/oct Highpass",
+            "inertia": 74
         },
         "gate": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "stereo-link": "Average",
-            "range": "-24",
-            "attack": "20",
-            "release": "250",
-            "threshold": "-18",
-            "ratio": "2",
-            "knee": "9",
-            "makeup": "0"
+            "range": -24,
+            "attack": 20,
+            "release": 250,
+            "threshold": -18,
+            "ratio": 2,
+            "knee": 9,
+            "makeup": 0
         },
         "limiter": {
-            "state": "false",
-            "input-gain": "5",
-            "limit": "0",
-            "lookahead": "5",
-            "release": "50",
-            "asc": "false",
-            "asc-level": "0.5",
-            "oversampling": "1"
+            "state": false,
+            "input-gain": 5,
+            "limit": 0,
+            "lookahead": 5,
+            "release": 50,
+            "asc": false,
+            "asc-level": 0.5,
+            "oversampling": 1
         },
         "maximizer": {
-            "state": "false",
-            "release": "24.979999999999997",
-            "ceiling": "-2",
-            "threshold": "-2"
+            "state": false,
+            "release": 24.979999999999997,
+            "ceiling": -2,
+            "threshold": -2
         },
         "pitch": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "cents": "0",
-            "semitones": "0",
-            "octaves": "0",
-            "crispness": "3",
-            "formant-preserving": "false",
-            "faster": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "cents": 0,
+            "semitones": 0,
+            "octaves": 0,
+            "crispness": 3,
+            "formant-preserving": false,
+            "faster": false
         },
         "reverb": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "room-size": "Large",
-            "decay-time": "1.5",
-            "hf-damp": "5000",
-            "diffusion": "0.5",
-            "amount": "-12",
-            "dry": "0",
-            "predelay": "0",
-            "bass-cut": "300",
-            "treble-cut": "5000"
+            "decay-time": 1.5,
+            "hf-damp": 5000,
+            "diffusion": 0.5,
+            "amount": -12,
+            "dry": 0,
+            "predelay": 0,
+            "bass-cut": 300,
+            "treble-cut": 5000
         },
         "multiband_compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "loudness": {
-            "state": "false",
-            "loudness": "-3.1000000000000001",
-            "output": "-6",
-            "link": "-9.0999999999999996"
+            "state": false,
+            "loudness": -3.1,
+            "output": -6,
+            "link": -9.1
         },
         "multiband_gate": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "stereo_tools": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "balance-in": "0",
-            "balance-out": "0",
-            "softclip": "false",
-            "mutel": "false",
-            "muter": "false",
-            "phasel": "false",
-            "phaser": "false",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "balance-in": 0,
+            "balance-out": 0,
+            "softclip": false,
+            "mutel": false,
+            "muter": false,
+            "phasel": false,
+            "phaser": false,
             "mode": "LR > LR (Stereo Default)",
-            "side-level": "-1",
-            "side-balance": "0.099999999999999992",
-            "middle-level": "3",
-            "middle-panorama": "-0.099999999999999242",
-            "stereo-base": "0",
-            "delay": "0",
-            "sc-level": "1",
-            "stereo-phase": "0"
+            "side-level": -1,
+            "side-balance": 0.09999999999999999,
+            "middle-level": 3,
+            "middle-panorama": -0.09999999999999924,
+            "stereo-base": 0,
+            "delay": 0,
+            "sc-level": 1,
+            "stereo-phase": 0
         },
         "convolver": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "kernel-path": "",
-            "ir-width": "87"
+            "ir-width": 87
         },
         "crystalizer": {
-            "state": "false",
-            "aggressive": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "aggressive": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "band0": {
-                "intensity": "12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 12,
+                "mute": false,
+                "bypass": false
             },
             "band1": {
-                "intensity": "3",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 3,
+                "mute": false,
+                "bypass": false
             },
             "band2": {
-                "intensity": "-13",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -13,
+                "mute": false,
+                "bypass": false
             },
             "band3": {
-                "intensity": "0",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 0,
+                "mute": false,
+                "bypass": false
             },
             "band4": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band5": {
-                "intensity": "-8",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -8,
+                "mute": false,
+                "bypass": false
             },
             "band6": {
-                "intensity": "7",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 7,
+                "mute": false,
+                "bypass": false
             },
             "band7": {
-                "intensity": "-15",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -15,
+                "mute": false,
+                "bypass": false
             },
             "band8": {
-                "intensity": "-9",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -9,
+                "mute": false,
+                "bypass": false
             },
             "band9": {
-                "intensity": "-19",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -19,
+                "mute": false,
+                "bypass": false
             },
             "band10": {
-                "intensity": "-21",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -21,
+                "mute": false,
+                "bypass": false
             },
             "band11": {
-                "intensity": "-10",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -10,
+                "mute": false,
+                "bypass": false
             },
             "band12": {
-                "intensity": "-12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -12,
+                "mute": false,
+                "bypass": false
             }
         },
         "autogain": {
-            "state": "false",
-            "detect-silence": "false",
-            "use-geometric-mean": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "target": "-23",
-            "weight-m": "1",
-            "weight-s": "1",
-            "weight-i": "1"
+            "state": false,
+            "detect-silence": false,
+            "use-geometric-mean": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "target": -23,
+            "weight-m": 1,
+            "weight-s": 1,
+            "weight-i": 1
         },
         "delay": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "time-l": "0",
-            "time-r": "0"
-        }
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "time-l": 0,
+            "time-r": 0
+        },
+        "blocklist": []
     }
 }

--- a/Pulse 15/Pulse 15.json
+++ b/Pulse 15/Pulse 15.json
@@ -1,413 +1,396 @@
 {
     "spectrum": {
-        "show": "true",
-        "n-points": "100",
-        "height": "100",
-        "use-custom-color": "false",
-        "fill": "true",
-        "show-bar-border": "true",
-        "scale": "1",
-        "exponent": "1",
-        "sampling-freq": "10",
-        "line-width": "2",
+        "show": true,
+        "n-points": 100,
+        "height": 100,
+        "use-custom-color": false,
+        "fill": true,
+        "show-bar-border": true,
+        "scale": 1,
+        "exponent": 1,
+        "sampling-freq": 10,
+        "line-width": 2,
         "type": "Bars",
         "color": [
-            "1",
-            "1",
-            "1",
-            "1"
+            1,
+            1,
+            1,
+            1
         ],
         "gradient-color": [
-            "0",
-            "0",
-            "0",
-            "1"
+            0,
+            0,
+            0,
+            1
         ]
     },
     "output": {
         "blacklist": "",
         "plugins_order": [
-            "limiter",
-            "autogain",
-            "gate",
-            "multiband_gate",
-            "compressor",
-            "multiband_compressor",
-            "convolver",
             "bass_enhancer",
             "exciter",
-            "crystalizer",
-            "stereo_tools",
-            "equalizer",
-            "reverb",
-            "delay",
-            "deesser",
-            "crossfeed",
-            "loudness",
-            "maximizer",
-            "filter",
-            "pitch"
+            "stereo_tools"
         ],
         "bass_enhancer": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "6",
-            "harmonics": "6.0000000000000089",
-            "scope": "200",
-            "floor": "25",
-            "blend": "-4",
-            "floor-active": "false",
-            "listen": "false"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 6,
+            "harmonics": 6.000000000000009,
+            "scope": 200,
+            "floor": 25,
+            "blend": -4,
+            "floor-active": false,
+            "listen": false
         },
         "compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "mode": "Downward",
-            "attack": "20",
-            "release": "100",
-            "threshold": "-12",
-            "ratio": "4",
-            "knee": "-6",
-            "makeup": "0",
+            "attack": 20,
+            "release": 100,
+            "threshold": -12,
+            "ratio": 4,
+            "knee": -6,
+            "makeup": 0,
             "sidechain": {
-                "listen": "false",
+                "listen": false,
                 "type": "Feed-forward",
                 "mode": "RMS",
                 "source": "Middle",
-                "preamp": "0",
-                "reactivity": "10",
-                "lookahead": "0"
+                "preamp": 0,
+                "reactivity": 10,
+                "lookahead": 0
             }
         },
         "crossfeed": {
-            "state": "false",
-            "fcut": "700",
-            "feed": "4.5"
+            "state": false,
+            "fcut": 700,
+            "feed": 4.5
         },
         "deesser": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "mode": "Wide",
-            "threshold": "-1",
-            "ratio": "2",
-            "laxity": "15",
-            "makeup": "1",
-            "f1-freq": "6000",
-            "f2-freq": "4500",
-            "f1-level": "1",
-            "f2-level": "12",
-            "f2-q": "1",
-            "sc-listen": "false"
+            "threshold": -1,
+            "ratio": 2,
+            "laxity": 15,
+            "makeup": 1,
+            "f1-freq": 6000,
+            "f2-freq": 4500,
+            "f1-level": 1,
+            "f2-level": 12,
+            "f2-q": 1,
+            "sc-listen": false
         },
         "equalizer": {
-            "state": "false",
+            "state": false,
             "mode": "IIR",
-            "num-bands": "30",
-            "input-gain": "0",
-            "output-gain": "0",
-            "split-channels": "false",
+            "num-bands": 30,
+            "input-gain": 0,
+            "output-gain": 0,
+            "split-channels": false,
             "left": {
                 "band0": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             },
             "right": {
@@ -415,610 +398,611 @@
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "22.59",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 22.59,
+                    "q": 4.36
                 },
                 "band1": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "28.440000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 28.44,
+                    "q": 4.36
                 },
                 "band2": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "35.799999999999997",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 35.8,
+                    "q": 4.36
                 },
                 "band3": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "45.07",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 45.07,
+                    "q": 4.36
                 },
                 "band4": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "56.740000000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 56.74,
+                    "q": 4.36
                 },
                 "band5": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "71.430000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 71.43,
+                    "q": 4.36
                 },
                 "band6": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "89.930000000000007",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 89.93,
+                    "q": 4.36
                 },
                 "band7": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "113.20999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 113.21,
+                    "q": 4.36
                 },
                 "band8": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "142.53",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 142.53,
+                    "q": 4.36
                 },
                 "band9": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "179.43000000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 179.43,
+                    "q": 4.36
                 },
                 "band10": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "225.88999999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 225.89,
+                    "q": 4.36
                 },
                 "band11": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "284.38",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 284.38,
+                    "q": 4.36
                 },
                 "band12": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "358.01999999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 358.02,
+                    "q": 4.36
                 },
                 "band13": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "450.72000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 450.72,
+                    "q": 4.36
                 },
                 "band14": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "567.41999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 567.42,
+                    "q": 4.36
                 },
                 "band15": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "714.34000000000003",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 714.34,
+                    "q": 4.36
                 },
                 "band16": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "899.28999999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 899.29,
+                    "q": 4.36
                 },
                 "band17": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1132.1500000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1132.15,
+                    "q": 4.36
                 },
                 "band18": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1425.29",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1425.29,
+                    "q": 4.36
                 },
                 "band19": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "1794.3299999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 1794.33,
+                    "q": 4.36
                 },
                 "band20": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2258.9299999999998",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2258.93,
+                    "q": 4.36
                 },
                 "band21": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "2843.8200000000002",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 2843.82,
+                    "q": 4.36
                 },
                 "band22": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "3580.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 3580.16,
+                    "q": 4.36
                 },
                 "band23": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "4507.1499999999996",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 4507.15,
+                    "q": 4.36
                 },
                 "band24": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "5674.1599999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 5674.16,
+                    "q": 4.36
                 },
                 "band25": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "7143.3500000000004",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 7143.35,
+                    "q": 4.36
                 },
                 "band26": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "8992.9400000000005",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 8992.94,
+                    "q": 4.36
                 },
                 "band27": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "11321.450000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 11321.45,
+                    "q": 4.36
                 },
                 "band28": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "14252.860000000001",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 14252.86,
+                    "q": 4.36
                 },
                 "band29": {
                     "type": "Bell",
                     "mode": "RLC (BT)",
                     "slope": "x1",
-                    "solo": "false",
-                    "mute": "false",
-                    "gain": "0",
-                    "frequency": "17943.279999999999",
-                    "q": "4.3600000000000003"
+                    "solo": false,
+                    "mute": false,
+                    "gain": 0,
+                    "frequency": 17943.28,
+                    "q": 4.36
                 }
             }
         },
         "exciter": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "amount": "3",
-            "harmonics": "4.0000000000000036",
-            "scope": "2000",
-            "ceil": "16000",
-            "blend": "1",
-            "ceil-active": "false",
-            "listen": "false"
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "amount": 3,
+            "harmonics": 4.0000000000000036,
+            "scope": 2000,
+            "ceil": 16000,
+            "blend": 1,
+            "ceil-active": false,
+            "listen": false
         },
         "filter": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "frequency": "100",
-            "resonance": "0.30000000000000004",
-            "mode": "12dB\/oct Highpass",
-            "inertia": "74"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "frequency": 100,
+            "resonance": 0.30000000000000004,
+            "mode": "12dB/oct Highpass",
+            "inertia": 74
         },
         "gate": {
-            "state": "false",
+            "state": false,
             "detection": "RMS",
             "stereo-link": "Average",
-            "range": "-24",
-            "attack": "20",
-            "release": "250",
-            "threshold": "-18",
-            "ratio": "2",
-            "knee": "9",
-            "makeup": "0"
+            "range": -24,
+            "attack": 20,
+            "release": 250,
+            "threshold": -18,
+            "ratio": 2,
+            "knee": 9,
+            "makeup": 0
         },
         "limiter": {
-            "state": "false",
-            "input-gain": "0",
-            "limit": "0",
-            "lookahead": "5",
-            "release": "50",
-            "asc": "false",
-            "asc-level": "0.5",
-            "oversampling": "1"
+            "state": false,
+            "input-gain": 0,
+            "limit": 0,
+            "lookahead": 5,
+            "release": 50,
+            "asc": false,
+            "asc-level": 0.5,
+            "oversampling": 1
         },
         "maximizer": {
-            "state": "false",
-            "release": "25",
-            "ceiling": "0",
-            "threshold": "0"
+            "state": false,
+            "release": 25,
+            "ceiling": 0,
+            "threshold": 0
         },
         "pitch": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "cents": "0",
-            "semitones": "0",
-            "octaves": "0",
-            "crispness": "3",
-            "formant-preserving": "false",
-            "faster": "false"
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "cents": 0,
+            "semitones": 0,
+            "octaves": 0,
+            "crispness": 3,
+            "formant-preserving": false,
+            "faster": false
         },
         "reverb": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "room-size": "Large",
-            "decay-time": "1.5",
-            "hf-damp": "5000",
-            "diffusion": "0.5",
-            "amount": "-12",
-            "dry": "0",
-            "predelay": "0",
-            "bass-cut": "300",
-            "treble-cut": "5000"
+            "decay-time": 1.5,
+            "hf-damp": 5000,
+            "diffusion": 0.5,
+            "amount": -12,
+            "dry": 0,
+            "predelay": 0,
+            "bass-cut": 300,
+            "treble-cut": 5000
         },
         "multiband_compressor": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "loudness": {
-            "state": "false",
-            "loudness": "-3.1000000000000001",
-            "output": "-6",
-            "link": "-9.0999999999999996"
+            "state": false,
+            "loudness": -3.1,
+            "output": -6,
+            "link": -9.1
         },
         "multiband_gate": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "freq0": "120",
-            "freq1": "1000",
-            "freq2": "6000",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "freq0": 120,
+            "freq1": 1000,
+            "freq2": 6000,
             "mode": "LR8",
             "subband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "lowband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "midband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             },
             "highband": {
-                "reduction": "-24",
-                "threshold": "-12",
-                "ratio": "2",
-                "attack": "150",
-                "release": "300",
-                "makeup": "0",
-                "knee": "9",
+                "reduction": -24,
+                "threshold": -12,
+                "ratio": 2,
+                "attack": 150,
+                "release": 300,
+                "makeup": 0,
+                "knee": 9,
                 "detection": "RMS",
-                "bypass": "false",
-                "solo": "false"
+                "bypass": false,
+                "solo": false
             }
         },
         "stereo_tools": {
-            "state": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "balance-in": "0",
-            "balance-out": "0",
-            "softclip": "false",
-            "mutel": "false",
-            "muter": "false",
-            "phasel": "false",
-            "phaser": "false",
+            "state": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "balance-in": 0,
+            "balance-out": 0,
+            "softclip": false,
+            "mutel": false,
+            "muter": false,
+            "phasel": false,
+            "phaser": false,
             "mode": "LR > LR (Stereo Default)",
-            "side-level": "5",
-            "side-balance": "0.24999999999999994",
-            "middle-level": "0",
-            "middle-panorama": "0.15999999999999998",
-            "stereo-base": "0",
-            "delay": "0",
-            "sc-level": "1",
-            "stereo-phase": "0"
+            "side-level": 5,
+            "side-balance": 0.24999999999999994,
+            "middle-level": 0,
+            "middle-panorama": 0.15999999999999998,
+            "stereo-base": 0,
+            "delay": 0,
+            "sc-level": 1,
+            "stereo-phase": 0
         },
         "convolver": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "kernel-path": "",
-            "ir-width": "100"
+            "ir-width": 100
         },
         "crystalizer": {
-            "state": "false",
-            "aggressive": "false",
-            "input-gain": "0",
-            "output-gain": "0",
+            "state": false,
+            "aggressive": false,
+            "input-gain": 0,
+            "output-gain": 0,
             "band0": {
-                "intensity": "12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 12,
+                "mute": false,
+                "bypass": false
             },
             "band1": {
-                "intensity": "10",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 10,
+                "mute": false,
+                "bypass": false
             },
             "band2": {
-                "intensity": "8",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 8,
+                "mute": false,
+                "bypass": false
             },
             "band3": {
-                "intensity": "6",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 6,
+                "mute": false,
+                "bypass": false
             },
             "band4": {
-                "intensity": "4",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 4,
+                "mute": false,
+                "bypass": false
             },
             "band5": {
-                "intensity": "2",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 2,
+                "mute": false,
+                "bypass": false
             },
             "band6": {
-                "intensity": "0",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": 0,
+                "mute": false,
+                "bypass": false
             },
             "band7": {
-                "intensity": "-2",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -2,
+                "mute": false,
+                "bypass": false
             },
             "band8": {
-                "intensity": "-4",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -4,
+                "mute": false,
+                "bypass": false
             },
             "band9": {
-                "intensity": "-6",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -6,
+                "mute": false,
+                "bypass": false
             },
             "band10": {
-                "intensity": "-8",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -8,
+                "mute": false,
+                "bypass": false
             },
             "band11": {
-                "intensity": "-10",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -10,
+                "mute": false,
+                "bypass": false
             },
             "band12": {
-                "intensity": "-12",
-                "mute": "false",
-                "bypass": "false"
+                "intensity": -12,
+                "mute": false,
+                "bypass": false
             }
         },
         "autogain": {
-            "state": "false",
-            "detect-silence": "false",
-            "use-geometric-mean": "true",
-            "input-gain": "0",
-            "output-gain": "0",
-            "target": "-23",
-            "weight-m": "1",
-            "weight-s": "1",
-            "weight-i": "1"
+            "state": false,
+            "detect-silence": false,
+            "use-geometric-mean": true,
+            "input-gain": 0,
+            "output-gain": 0,
+            "target": -23,
+            "weight-m": 1,
+            "weight-s": 1,
+            "weight-i": 1
         },
         "delay": {
-            "state": "false",
-            "input-gain": "0",
-            "output-gain": "0",
-            "time-l": "0",
-            "time-r": "0"
-        }
+            "state": false,
+            "input-gain": 0,
+            "output-gain": 0,
+            "time-l": 0,
+            "time-r": 0
+        },
+        "blocklist": []
     }
 }


### PR DESCRIPTION
[EasyEffects](https://github.com/wwmm/easyeffects) uses a different preset structure since 6.0.0 ([discussion](https://github.com/wwmm/easyeffects/issues/904#issuecomment-862572748))
This should make the presets compatible.

How about creating a separate branch for EasyEffects and referencing it in the readme?