### PR TITLE
Added preset file for IB Pro 14 Gen 7's internal speakers.

### DIFF
--- a/InfinityBook Pro 14/Gen 7/InfinityBook Pro 14 Gen 7 (internal speakers).json
+++ b/InfinityBook Pro 14/Gen 7/InfinityBook Pro 14 Gen 7 (internal speakers).json
@@ -1,0 +1,1044 @@
+{
+    "spectrum": {
+        "show": "true",
+        "n-points": "100",
+        "height": "100",
+        "use-custom-color": "false",
+        "fill": "true",
+        "show-bar-border": "true",
+        "sampling-freq": "10",
+        "line-width": "2",
+        "type": "Bars",
+        "color": [
+            "1",
+            "1",
+            "1",
+            "1"
+        ],
+        "color-axis-labels": [
+            "1",
+            "1",
+            "1",
+            "1"
+        ],
+        "gradient-color": [
+            "0",
+            "0",
+            "0",
+            "1"
+        ]
+    },
+    "output": {
+        "blocklist": "",
+        "plugins_order": [
+            "filter",
+            "bass_enhancer",
+            "multiband_compressor",
+            "stereo_tools",
+            "limiter",
+            "autogain",
+            "gate",
+            "compressor",
+            "multiband_gate",
+            "convolver",
+            "exciter",
+            "crystalizer",
+            "reverb",
+            "equalizer",
+            "delay",
+            "deesser",
+            "crossfeed",
+            "loudness",
+            "maximizer",
+            "pitch",
+            "rnnoise"
+        ],
+        "bass_enhancer": {
+            "state": "true",
+            "input-gain": "0",
+            "output-gain": "0",
+            "amount": "14.999999999999948",
+            "harmonics": "9.9999999999999947",
+            "scope": "200",
+            "floor": "10",
+            "blend": "1",
+            "floor-active": "true",
+            "listen": "false"
+        },
+        "compressor": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "mode": "Downward",
+            "attack": "20",
+            "release": "100",
+            "release-threshold": "-200",
+            "threshold": "-12",
+            "ratio": "4",
+            "knee": "-6",
+            "makeup": "0",
+            "boost-threshold": "-72",
+            "sidechain": {
+                "listen": "false",
+                "type": "Feed-forward",
+                "mode": "RMS",
+                "source": "Middle",
+                "preamp": "0",
+                "reactivity": "10",
+                "lookahead": "0"
+            },
+            "hpf-mode": "off",
+            "hpf-frequency": "10",
+            "lpf-mode": "off",
+            "lpf-frequency": "20000"
+        },
+        "crossfeed": {
+            "state": "false",
+            "fcut": "700",
+            "feed": "4.5"
+        },
+        "deesser": {
+            "state": "false",
+            "detection": "RMS",
+            "mode": "Wide",
+            "threshold": "-18",
+            "ratio": "3",
+            "laxity": "15",
+            "makeup": "0",
+            "f1-freq": "6000",
+            "f2-freq": "4500",
+            "f1-level": "0",
+            "f2-level": "12",
+            "f2-q": "1",
+            "sc-listen": "false"
+        },
+        "equalizer": {
+            "state": "false",
+            "mode": "IIR",
+            "num-bands": "30",
+            "input-gain": "0",
+            "output-gain": "0",
+            "split-channels": "false",
+            "left": {
+                "band0": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "22.59",
+                    "q": "4.3600000000000003"
+                },
+                "band1": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "28.440000000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band2": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "35.799999999999997",
+                    "q": "4.3600000000000003"
+                },
+                "band3": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "45.07",
+                    "q": "4.3600000000000003"
+                },
+                "band4": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "56.740000000000002",
+                    "q": "4.3600000000000003"
+                },
+                "band5": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "71.430000000000007",
+                    "q": "4.3600000000000003"
+                },
+                "band6": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "89.930000000000007",
+                    "q": "4.3600000000000003"
+                },
+                "band7": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "113.20999999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band8": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "142.53",
+                    "q": "4.3600000000000003"
+                },
+                "band9": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "179.43000000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band10": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "225.88999999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band11": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "284.38",
+                    "q": "4.3600000000000003"
+                },
+                "band12": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "358.01999999999998",
+                    "q": "4.3600000000000003"
+                },
+                "band13": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "450.72000000000003",
+                    "q": "4.3600000000000003"
+                },
+                "band14": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "567.41999999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band15": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "714.34000000000003",
+                    "q": "4.3600000000000003"
+                },
+                "band16": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "899.28999999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band17": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1132.1500000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band18": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1425.29",
+                    "q": "4.3600000000000003"
+                },
+                "band19": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1794.3299999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band20": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "2258.9299999999998",
+                    "q": "4.3600000000000003"
+                },
+                "band21": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "2843.8200000000002",
+                    "q": "4.3600000000000003"
+                },
+                "band22": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "3580.1599999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band23": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "4507.1499999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band24": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "5674.1599999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band25": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "7143.3500000000004",
+                    "q": "4.3600000000000003"
+                },
+                "band26": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "8992.9400000000005",
+                    "q": "4.3600000000000003"
+                },
+                "band27": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "11321.450000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band28": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "14252.860000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band29": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "17943.279999999999",
+                    "q": "4.3600000000000003"
+                }
+            },
+            "right": {
+                "band0": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "22.59",
+                    "q": "4.3600000000000003"
+                },
+                "band1": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "28.440000000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band2": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "35.799999999999997",
+                    "q": "4.3600000000000003"
+                },
+                "band3": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "45.07",
+                    "q": "4.3600000000000003"
+                },
+                "band4": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "56.740000000000002",
+                    "q": "4.3600000000000003"
+                },
+                "band5": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "71.430000000000007",
+                    "q": "4.3600000000000003"
+                },
+                "band6": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "89.930000000000007",
+                    "q": "4.3600000000000003"
+                },
+                "band7": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "113.20999999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band8": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "142.53",
+                    "q": "4.3600000000000003"
+                },
+                "band9": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "179.43000000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band10": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "225.88999999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band11": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "284.38",
+                    "q": "4.3600000000000003"
+                },
+                "band12": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "358.01999999999998",
+                    "q": "4.3600000000000003"
+                },
+                "band13": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "450.72000000000003",
+                    "q": "4.3600000000000003"
+                },
+                "band14": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "567.41999999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band15": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "714.34000000000003",
+                    "q": "4.3600000000000003"
+                },
+                "band16": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "899.28999999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band17": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1132.1500000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band18": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1425.29",
+                    "q": "4.3600000000000003"
+                },
+                "band19": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "1794.3299999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band20": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "2258.9299999999998",
+                    "q": "4.3600000000000003"
+                },
+                "band21": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "2843.8200000000002",
+                    "q": "4.3600000000000003"
+                },
+                "band22": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "3580.1599999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band23": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "4507.1499999999996",
+                    "q": "4.3600000000000003"
+                },
+                "band24": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "5674.1599999999999",
+                    "q": "4.3600000000000003"
+                },
+                "band25": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "7143.3500000000004",
+                    "q": "4.3600000000000003"
+                },
+                "band26": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "8992.9400000000005",
+                    "q": "4.3600000000000003"
+                },
+                "band27": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "11321.450000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band28": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "14252.860000000001",
+                    "q": "4.3600000000000003"
+                },
+                "band29": {
+                    "type": "Bell",
+                    "mode": "RLC (BT)",
+                    "slope": "x1",
+                    "solo": "false",
+                    "mute": "false",
+                    "gain": "0",
+                    "frequency": "17943.279999999999",
+                    "q": "4.3600000000000003"
+                }
+            }
+        },
+        "exciter": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "amount": "4",
+            "harmonics": "9.9999999999999947",
+            "scope": "7846",
+            "ceil": "16076",
+            "blend": "-5",
+            "ceil-active": "false",
+            "listen": "false"
+        },
+        "filter": {
+            "state": "true",
+            "input-gain": "0",
+            "output-gain": "0",
+            "frequency": "150",
+            "resonance": "0.69999999999999996",
+            "mode": "36dB\/oct Highpass",
+            "inertia": "74"
+        },
+        "gate": {
+            "state": "false",
+            "detection": "RMS",
+            "stereo-link": "Average",
+            "range": "-24",
+            "attack": "20",
+            "release": "250",
+            "threshold": "-18",
+            "ratio": "2",
+            "knee": "9",
+            "input": "0",
+            "makeup": "0"
+        },
+        "limiter": {
+            "state": "true",
+            "input-gain": "0",
+            "limit": "0",
+            "lookahead": "4",
+            "release": "8",
+            "auto-level": "false",
+            "asc": "false",
+            "asc-level": "0.5",
+            "oversampling": "1",
+            "output-gain": "0"
+        },
+        "maximizer": {
+            "state": "false",
+            "release": "24.979999999999997",
+            "ceiling": "-2",
+            "threshold": "-2"
+        },
+        "pitch": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "cents": "0",
+            "semitones": "0",
+            "octaves": "0",
+            "crispness": "3",
+            "formant-preserving": "false"
+        },
+        "reverb": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "room-size": "Large",
+            "decay-time": "1.5",
+            "hf-damp": "5000",
+            "diffusion": "0.5",
+            "amount": "-12",
+            "dry": "0",
+            "predelay": "0",
+            "bass-cut": "300",
+            "treble-cut": "5000"
+        },
+        "multiband_compressor": {
+            "state": "true",
+            "input-gain": "-6",
+            "output-gain": "0",
+            "freq0": "250",
+            "freq1": "1250",
+            "freq2": "5000",
+            "mode": "LR8",
+            "subband": {
+                "threshold": "-16",
+                "ratio": "5",
+                "attack": "150",
+                "release": "300",
+                "makeup": "4.4999999999999982",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "lowband": {
+                "threshold": "-24",
+                "ratio": "3",
+                "attack": "150",
+                "release": "200",
+                "makeup": "3.5000000000000031",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "midband": {
+                "threshold": "-24",
+                "ratio": "3",
+                "attack": "100",
+                "release": "150",
+                "makeup": "4.500000000000016",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "highband": {
+                "threshold": "-24",
+                "ratio": "4",
+                "attack": "80",
+                "release": "120",
+                "makeup": "4.5",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            }
+        },
+        "loudness": {
+            "state": "false",
+            "fft": "4096",
+            "std": "ISO226-2003",
+            "input": "0",
+            "volume": "0"
+        },
+        "multiband_gate": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "freq0": "120",
+            "freq1": "1000",
+            "freq2": "6000",
+            "mode": "LR8",
+            "subband": {
+                "reduction": "-24",
+                "threshold": "-12",
+                "ratio": "2",
+                "attack": "150",
+                "release": "300",
+                "makeup": "0",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "lowband": {
+                "reduction": "-24",
+                "threshold": "-12",
+                "ratio": "2",
+                "attack": "150",
+                "release": "300",
+                "makeup": "0",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "midband": {
+                "reduction": "-24",
+                "threshold": "-12",
+                "ratio": "2",
+                "attack": "150",
+                "release": "300",
+                "makeup": "0",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            },
+            "highband": {
+                "reduction": "-24",
+                "threshold": "-12",
+                "ratio": "2",
+                "attack": "150",
+                "release": "300",
+                "makeup": "0",
+                "knee": "9",
+                "detection": "RMS",
+                "bypass": "false",
+                "solo": "false"
+            }
+        },
+        "stereo_tools": {
+            "state": "true",
+            "input-gain": "0",
+            "output-gain": "0",
+            "balance-in": "0",
+            "balance-out": "0",
+            "softclip": "false",
+            "mutel": "false",
+            "muter": "false",
+            "phasel": "false",
+            "phaser": "false",
+            "mode": "LR > LR (Stereo Default)",
+            "side-level": "-1",
+            "side-balance": "0.099999999999999992",
+            "middle-level": "3",
+            "middle-panorama": "-0.099999999999999242",
+            "stereo-base": "0.25000000000000006",
+            "delay": "0",
+            "sc-level": "1",
+            "stereo-phase": "0"
+        },
+        "convolver": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "kernel-path": "",
+            "ir-width": "87"
+        },
+        "crystalizer": {
+            "state": "false",
+            "aggressive": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "band0": {
+                "intensity": "12",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band1": {
+                "intensity": "3",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band2": {
+                "intensity": "-13",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band3": {
+                "intensity": "0",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band4": {
+                "intensity": "-15",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band5": {
+                "intensity": "-8",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band6": {
+                "intensity": "7",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band7": {
+                "intensity": "-15",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band8": {
+                "intensity": "-9",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band9": {
+                "intensity": "-19",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band10": {
+                "intensity": "-21",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band11": {
+                "intensity": "-10",
+                "mute": "false",
+                "bypass": "false"
+            },
+            "band12": {
+                "intensity": "-12",
+                "mute": "false",
+                "bypass": "false"
+            }
+        },
+        "autogain": {
+            "state": "false",
+            "detect-silence": "false",
+            "use-geometric-mean": "true",
+            "input-gain": "0",
+            "output-gain": "0",
+            "target": "-23",
+            "weight-m": "1",
+            "weight-s": "1",
+            "weight-i": "1"
+        },
+        "delay": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "time-l": "0",
+            "time-r": "0"
+        },
+        "rnnoise": {
+            "state": "false",
+            "input-gain": "0",
+            "output-gain": "0",
+            "model-path": "Standard RNNoise Model"
+        }
+    }
+}


### PR DESCRIPTION
Created a preset for the IB Pro 14 Gen 7's internal speakers by following roughly this guide: 

https://wwmm.github.io/easyeffects/guide_1.html

Tested mainly with different styles of music from Spotify Linux client and they all are pretty much improved noticeably over the hardware defaults.

The assumption made here is: Application volume is set at 100%, then PulseEffects does it's job and actual user volume is controlled by hardware FN keys/system settings.

@vinzv I would *assume* that this profile should work the same for the Gen 8 given that it seems to have the same or a very similar chassis, but you might want to sanity check that.